### PR TITLE
strip trailing white space for payloads on pitchfork wordlist

### DIFF
--- a/resources/examples/pitchFork.py
+++ b/resources/examples/pitchFork.py
@@ -7,9 +7,9 @@ def queueRequests(target, wordlists):
     payload1 = []
     payload2 = []
     for eachWord in open('/usr/share/dict/numbers.txt'):
-        payload1.append(eachWord)
+        payload1.append(eachWord.strip())
     for eachWord in open('/usr/share/dict/posspass.txt'):
-        payload2.append(eachWord)
+        payload2.append(eachWord.strip())
     for i in range(0,len(payload2) if(len(payload2)<=len(payload1)) else len(payload1)):
         # execute till the length of smaller payload.
         engine.queue(target.req, [payload1[i], payload2[i]])


### PR DESCRIPTION
The current code doesn't remove the trailing white spaces on the append function for pitchfork. I added a little fix for the bug. Thanks!